### PR TITLE
Change order of detection of shellcheck dialect

### DIFF
--- a/autoload/ale/handlers/shellcheck.vim
+++ b/autoload/ale/handlers/shellcheck.vim
@@ -22,10 +22,10 @@ function! ale#handlers#shellcheck#GetShellcheckDialectDirective(buffer) abort
 endfunction
 
 function! ale#handlers#shellcheck#GetDialectArgument(buffer) abort
-    let l:shell_type = ale#handlers#sh#GetShellType(a:buffer)
+    let l:shell_type = ale#handlers#shellcheck#GetShellcheckDialectDirective(a:buffer)
 
     if empty(l:shell_type)
-        let l:shell_type = ale#handlers#shellcheck#GetShellcheckDialectDirective(a:buffer)
+        let l:shell_type = ale#handlers#sh#GetShellType(a:buffer)
     endif
 
     if !empty(l:shell_type)


### PR DESCRIPTION
In a situation where the filetype can be wrong (example: something.sh
which is written in bash dialect) and has no hash-bang (since it is
meant to be sourced) then the override specified within the script will
be ignored.

It probably is the most right thing to do if the script author has added
a specific directive; it should trump everything else.

NB: Sorry, I am a newbie to vim scripting. Couldn't figure out how to run tests.